### PR TITLE
feat: Babylon Staking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ const result = verifyContract("babylon:staking", {
   covenantThreshold: 1,
   minUnbondingTime: 101,
   stakingDuration: 144,
-  magicBytes: "62627434",
 },{
   address: "",
   publicKey: ""

--- a/src/plugins/babylon/staking/plugin.test.ts
+++ b/src/plugins/babylon/staking/plugin.test.ts
@@ -21,7 +21,6 @@ describe("babylon:staking", () => {
       covenantThreshold: 1,
       minUnbondingTime: 101,
       stakingDuration: 144,
-      magicBytes: "62627434",
     };
     expect(() => plugin.verify(params, account)).not.toThrow();
     const result = plugin.verify(params, account);
@@ -50,7 +49,6 @@ describe("babylon:staking", () => {
       covenantThreshold: 1,
       minUnbondingTime: 101,
       stakingDuration: 144,
-      magicBytes: "62627434",
     };
     expect(() => plugin.verify(params, account)).not.toThrow();
     const result = plugin.verify(params, account);

--- a/src/plugins/babylon/staking/staking-contract.ts
+++ b/src/plugins/babylon/staking/staking-contract.ts
@@ -16,7 +16,6 @@ export function getStakingContract(
     stakerPk: string;
     covenantPks: string[];
     finalityProviders: string[];
-    magicBytes: string;
     covenantThreshold: number;
     minUnbondingTime: number;
     stakingDuration: number;

--- a/src/plugins/babylon/staking/staking-contract.ts
+++ b/src/plugins/babylon/staking/staking-contract.ts
@@ -1,4 +1,4 @@
-import { opcodes, script, payments, networks, initEccLib } from "bitcoinjs-lib";
+import { payments, initEccLib } from "bitcoinjs-lib";
 import { StakingScriptData } from "@babylonlabs-io/btc-staking-ts";
 import { Taptree } from "bitcoinjs-lib/src/types";
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
@@ -46,7 +46,6 @@ export function getStakingContract(
     timelockScript,
     unbondingScript,
     slashingScript,
-    unbondingTimelockScript,
   } = stakingScriptData.buildScripts();
 
   // Build input tapleaf script


### PR DESCRIPTION
- Removes `magicBytes`
- Removes unused code and imports

`Unbonding timelock` (`minUnbondingTime`) is not needed for the staking transaction definition, but indeed is needed to create the `new StakingScriptData`