### PR TITLE
chore: add additional params to make it ledger compatible

### DIFF
--- a/src/plugins/babylon/README.md
+++ b/src/plugins/babylon/README.md
@@ -33,6 +33,12 @@ export const BABYLON_PLUGINS = {
     name: "Babylon Slashing Refund",
     description: "Babylon Slashing Refund",
     params: {} as BabylonSlashingPluginParams
+  },
+  SLASHING_BURN: {
+    id: "babylon:slashing-burn",
+    name: "Babylon Slashing Burn",
+    description: "Babylon Slashing Burn",
+    params: {} as BabylonSlashingBurnPluginParams
   }
 } as const;
 ```
@@ -73,6 +79,13 @@ interface BabylonUnbondingPluginParams extends ContractParams {
 interface BabylonSlashingPluginParams extends ContractParams {
   stakerPk: string
   unbondingTimeBlocks: number
+}
+```
+
+#### 4️⃣ BabylonSlashingBurnPluginParams
+```ts
+interface BabylonSlashingBurnPluginParams extends ContractParams {
+  slashingPkScriptHex: string
 }
 ```
 

--- a/src/plugins/babylon/slashing/plugin.test.ts
+++ b/src/plugins/babylon/slashing/plugin.test.ts
@@ -12,7 +12,8 @@ describe("babylon:slashing", () => {
     const params = {
       stakerPk:
         "b3e9e3140da9d4a148b1471d9b3d4b1c1ff9fb69f421e19a9443365b2a647bf2",
-      unbondingTimeBlocks: 144
+      unbondingTimeBlocks: 144,
+      slashingFeeSat: 10000
     };
     const result = plugin.verify(params, account);
     expect(result.address).toBe(
@@ -31,7 +32,8 @@ describe("babylon:slashing", () => {
     const params = {
       stakerPk:
         "b3e9e3140da9d4a148b1471d9b3d4b1c1ff9fb69f421e19a9443365b2a647bf2",
-      unbondingTimeBlocks: 144
+      unbondingTimeBlocks: 144,
+      slashingFeeSat: 10000
     };
     const result = plugin.verify(params, account);
     expect(result.address).toBe(

--- a/src/plugins/babylon/types/types.ts
+++ b/src/plugins/babylon/types/types.ts
@@ -29,6 +29,13 @@ export const BABYLON_PLUGINS = {
 
 /**
  * Parameters for the Babylon Staking Plugin.
+ * 
+ * @param stakerPk - The public key of the staker.
+ * @param covenantPks - The public keys of the covenants.
+ * @param finalityProviders - The public keys of the finality providers.
+ * @param covenantThreshold - The threshold for the covenants.
+ * @param minUnbondingTime - The minimum time to unbond for.
+ * @param stakingDuration - The duration of the staking.
  */
 export interface BabylonStakingPluginParams extends ContractParams {
   stakerPk: string
@@ -41,6 +48,15 @@ export interface BabylonStakingPluginParams extends ContractParams {
 
 /**
  * Parameters for the Babylon Unbonding Plugin.
+ * 
+ * @param stakerPk - The public key of the staker.
+ * @param covenantPks - The public keys of the covenants.
+ * @param finalityProviders - The public keys of the finality providers.
+ * @param covenantThreshold - The threshold for the covenants.
+ * @param unbondingTimeBlocks - The number of blocks to unbond for.
+ * @param unbondingFeeSat - The fee to pay for unbonding. This value is not used
+ * for deriving the script/tapscript address, but it's an important value for
+ * the staker to know in the UI.
  */
 export interface BabylonUnbondingPluginParams extends ContractParams {
   stakerPk: string
@@ -48,19 +64,29 @@ export interface BabylonUnbondingPluginParams extends ContractParams {
   finalityProviders: string[]
   covenantThreshold: number
   unbondingTimeBlocks: number
+  unbondingFeeSat: number
 }
 
 /**
  * Parameters for the Babylon Slashing Plugin Params.
  * Both for Staking Slashing and Unbonding Slashing.
+ *
+ * @param stakerPk - The public key of the staker.
+ * @param unbondingTimeBlocks - The number of blocks to unbond for.
+ * @param slashingFeeSat - The fee to pay for slashing if it occurs. This value
+ * is not used for deriving the script/tapscript address, but it's an important
+ * value for the staker to know in the UI.
  */
 export interface BabylonSlashingPluginParams extends ContractParams {
   stakerPk: string
   unbondingTimeBlocks: number
+  slashingFeeSat: number
 }
 
 /**
  * Parameters for the Babylon Slashing Burn Plugin.
+ *
+ * @param slashingPkScriptHex - The script hex of the slashing.
  */
 export interface BabylonSlashingBurnPluginParams extends ContractParams {
   slashingPkScriptHex: string

--- a/src/plugins/babylon/unbonding/plugin.test.ts
+++ b/src/plugins/babylon/unbonding/plugin.test.ts
@@ -20,6 +20,7 @@ describe("babylon:unbonding", () => {
       ],
       covenantThreshold: 1,
       unbondingTimeBlocks: 101,
+      unbondingFeeSat: 10000
     };
     const result = plugin.verify(params, account);
     expect(result.address).toBe(
@@ -45,7 +46,8 @@ describe("babylon:unbonding", () => {
         "50000074c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
       ],
       covenantThreshold: 1,
-      unbondingTimeBlocks: 144
+      unbondingTimeBlocks: 144,
+      unbondingFeeSat: 10000
     };
     const result = plugin.verify(params, account);
     expect(result.address).toBe(


### PR DESCRIPTION
Adding additional params for unbonding and slashing plugins. 
Those new fields are not used in the derive of tapscript address, but is needed for ledger app to make use of the contract defined here via signPsbt. (ledger also validates the slashing and unbonding fees)

